### PR TITLE
adds an api to retrieve the list of currencies available for trading on bisq

### DIFF
--- a/api/currencies/apidoc.php
+++ b/api/currencies/apidoc.php
@@ -1,0 +1,50 @@
+<?php
+
+class api_currencies {
+    
+    static function get_description() {
+        return "Provides list of available currencies for a given base currency.";
+    }
+    
+    static function get_params() {
+        return [
+                 ['param' => 'basecurrency', 'desc' => 'base currency identifier', 'required' => false, 'values' => null, 'default' => 'BTC'],
+                 ['param' => 'type', 'desc' => 'type of currencies to include in results', 'required' => false, 'values' => 'crypto | fiat | all', 'default' => 'all'],
+                 ['param' => 'format', 'desc' => 'format of return data', 'required' => false, 'values' => 'json | jsonpretty', 'default' => 'jsonpretty'],
+               ];
+    }
+
+    static function get_examples() {
+        $examples = [];
+        $examples[] = 
+                        [ 'request' => '/currencies',
+                          'response' => <<< END
+{
+    "AED": {
+        "code": "AED",
+        "name": "United Arab Emirates Dirham",
+        "precision": 8,
+        "type": "fiat"
+    },
+    "AIB": {
+        "code": "AIB",
+        "name": "Advanced Internet Blocks",
+        "precision": 8,
+        "type": "crypto"
+    },
+    ...
+}
+END
+                        ];
+                        
+        return $examples;
+    }
+    
+    static function get_notes() {
+        return ['In practice, the same currencies are available for every basecurrency so this API can be called just once, omitting the basecurrency parameter.'];
+    }
+    
+    static function get_seealso() {
+        return [];
+    }
+}

--- a/api/currencies/index.php
+++ b/api/currencies/index.php
@@ -1,0 +1,34 @@
+<?php
+
+require_once( __DIR__ . '/../../lib/currencies.class.php');
+require_once( __DIR__ . '/../../lib/primary_market.class.php');
+
+$format = @$_GET['format'] ?: 'jsonpretty';  // jsonpretty, or json.
+$basecurrency = @$_GET['basecurrency'] ?: 'BTC';  // default to BTC.
+$type = @$_GET['type'] ?: 'all';
+
+try {
+    $network = primary_market::get_network($basecurrency);
+    $currencies = new currencies($network);
+    
+    switch($type) {
+        case 'fiat':   $results = $currencies->get_all_fiat(); break;
+        case 'crypto': $results = $currencies->get_all_crypto(); break;
+        case 'all':    $results = $currencies->get_all_currencies(); break;
+        default: bail("Invalid value for type parameter"); break;
+    }
+    
+    echo json_encode( $results, $format == 'json' ? 0 : JSON_PRETTY_PRINT );
+}
+catch( Exception $e ) {
+//  for dev/debug.
+    if( @$_GET['debug'] ) {
+        _global_exception_handler( $e );
+    }
+    bail($e->getCode() == 2 ? $e->getMessage() : "An unexpected error occurred.");    
+}
+
+function bail($msg) {
+    $result = ["success" => 0, "error" => $msg ];
+    die( json_encode( $result, $GLOBALS['format'] == 'json' ? 0 : JSON_PRETTY_PRINT ) );
+}


### PR DESCRIPTION
This seemed to be a missing API.  I followed the format of the other APIs.   I hope it is useful...

Here is the documentation that is auto generated on the /api page.

**/api/currencies**
Provides list of available currencies for a given base currency.
**Sample Request**
    https://markets.bisq.network/api/currencies
**Sample Response**
```
{
    "AED": {
        "code": "AED",
        "name": "United Arab Emirates Dirham",
        "precision": 8,
        "type": "fiat"
    },
    "AIB": {
        "code": "AIB",
        "name": "Advanced Internet Blocks",
        "precision": 8,
        "type": "crypto"
    },
    ...
}
```
**Parameters**

|param|desc|required|values|default|
|--------|------|----------|-------|---------|
|basecurrency|base currency identifier|No|BTC|
|type|type of currencies to include in results|No|crypto \| fiat \| all| 	all|
|format|format of return data|No|	json \| jsonpretty|jsonpretty|

**Notes**
* In practice, the same currencies are available for every basecurrency so this API can be called just once, omitting the basecurrency parameter.

