### PR TITLE
Pr issue 6

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -33,6 +33,10 @@ function e($buf) {
     return htmlentities( $buf );
 }
 
+function linkify($buf) {
+    return preg_replace('/\[(.*)\]\(http(.*)\)/', '<a href="http\\2">\\1</a>', $buf);
+}
+
 ?>
 
 <html>
@@ -109,7 +113,7 @@ div.params div {
 <?php foreach( $apis as $method => $api ): ?>
 <div class="api widget">
     <div class="method" id="<?= e($method) ?>">/api/<?= e($method) ?></div>
-    <div class="description"><?= e($api->get_description()) ?></div>
+    <div class="description"><?= linkify(e($api->get_description())) ?></div>
     <div class="examples">
         <?php foreach($api->get_examples() as $example): ?>
         <?php $url = 'https://markets.bisq.network/api' . e($example['request']); ?>
@@ -134,7 +138,7 @@ div.params div {
         <h4>Notes</h4>
         <ul>
         <?php foreach($api->get_notes() as $note): ?>
-        <li class="noteitem"><?= e($note) ?></li>
+        <li class="noteitem"><?= linkify(e($note)) ?></li>
         <?php endforeach ?>
         </ul>
     </div>

--- a/api/trades/apidoc.php
+++ b/api/trades/apidoc.php
@@ -28,17 +28,21 @@ class api_trades {
 [
     {
         "direction": "SELL",
-        "price": "562.51610000",
-        "amount": "0.30000000",
-        "trade_id": "df7bd928-2940-4524-90cf-8dc5717fcad8",
-        "trade_date": 1472947568822
+        "price": "2375.72500000",
+        "amount": "0.05000000",
+        "volume": "118.78620000",
+        "payment_method": "SEPA",
+        "trade_id": "BLBJHGL-b644851d-f822-418a-8035-955f7a02eff9-051",
+        "trade_date": 1501095828824
     },
     {
         "direction": "SELL",
-        "price": "552.48340000",
+        "price": "2148.50230000",
         "amount": "0.20000000",
-        "trade_id": "e9b4f424-61b1-494a-bd1e-9142ce65b1d4",
-        "trade_date": 1472937060362
+        "volume": "429.70040000",
+        "payment_method": "SEPA",
+        "trade_id": "dcwyx9-1a89dece-5039-4ff7-89c9-7ed52b84bc88-051",
+        "trade_date": 1501088841011
     }
 ]
 END
@@ -52,7 +56,8 @@ END
                 'if the market parameter is "all" then up to limit trades will be returned, date sorted, across all markets. Also a "market" field is added to each trade result.',
                 'this api will return a maximum of 2000 trades per call',
                 'if trade_id_from or trade_id_to is used and a matching trade is not found for each, then no results are returned',
-                'The Bisq app does not presently use a trade_id internally.  The trade_id in this api is actually the bisq offerId.'
+                'The Bisq app does not presently use a trade_id internally.  The trade_id in this api is actually the bisq offerId.',
+                'Possible values for payment_method can change over time.  For most current, see [PaymentMethod.java](https://raw.githubusercontent.com/bisq-network/bisq-core/master/src/main/java/bisq/core/payment/payload/PaymentMethod.java)',
                 ];
     }
     

--- a/api/trades/index.php
+++ b/api/trades/index.php
@@ -18,7 +18,15 @@ if( !$market ) {
 
 try {
     
-    $fields = ['market' => 'market', 'direction', 'tradePrice' => 'price', 'tradeAmount' => 'amount', 'offerId' => 'trade_id', 'tradeDate' => 'trade_date'];
+    $fields = ['market' => 'market',
+               'direction',
+               'tradePrice' => 'price',
+               'tradeAmount' => 'amount',
+               'tradeVolume' => 'volume',
+               'paymentMethod' => 'payment_method',
+               'offerId' => 'trade_id',
+               'tradeDate' => 'trade_date',
+              ];
     if( $market != 'all' ) {
         unset( $fields['market'] );
     }

--- a/lib/trades.class.php
+++ b/lib/trades.class.php
@@ -100,6 +100,7 @@ class trades {
             if( !@$integeramounts ) {
                 $trade['tradePrice'] = btcutil::int_to_btc( $trade['tradePrice'] );
                 $trade['tradeAmount'] = btcutil::int_to_btc( $trade['tradeAmount'] );
+                $trade['tradeVolume'] = btcutil::int_to_btc( $trade['tradeVolume'] );
                 $trade['offerAmount'] = btcutil::int_to_btc( $trade['offerAmount'] );
                 $trade['offerMinAmount'] = btcutil::int_to_btc( $trade['offerMinAmount'] );
             }
@@ -215,7 +216,7 @@ class trades {
             // HACK: filter out LTC base currency trades before 2017-06-28, because the historic data has some
             // bogus data that was made for testing or something.
             if($this->network == 'ltc_mainnet' && $trade['tradeDate'] < $ltc_start_ts) {
-		unset( $data[$idx]);
+                unset( $data[$idx]);
                 continue;
             }
             


### PR DESCRIPTION
This implements the requests in issue #6 for the /trades api, namely:
1. include payment method in the response
2. include volume field to indicate precise amount of primary currency traded.

note that volume could be calculated previously by multiplying price*amount, but the floating point multiplication often leaves numbers like 1.999999999 instead of 2.

note also that primary currency does not mean basecurrency aka bitcoin.  Rather, primary currency is always the currency that is 2nd in the market identifer, eg xmr_btc, btc is primary.  or btc_usd, usd is primary.  The rule in bisq is that fiat currencies are always primary against basecurrency (btc), and basecurrency is primary against other cryptocurrencies.  So if one wants to know amount of btc traded for any given market, one would use this logic:
```
    list($left, $right) = explode('_', $market_id);
    $btc_amount = $right == 'BTC' ? $volume : $amount;
```
I needed to link to [PaymentMethod.java](https://raw.githubusercontent.com/bisq-network/bisq-core/master/src/main/java/bisq/core/payment/payload/PaymentMethod.java) in the apidoc, and it was escaping all html entities, so I added a capability to detect markdown-style links in an API description or notes.

**Sample Response**   ( from the updated apidoc )
```
[
    {
        "direction": "SELL",
        "price": "2375.72500000",
        "amount": "0.05000000",
        "volume": "118.78620000",
        "payment_method": "SEPA",
        "trade_id": "BLBJHGL-b644851d-f822-418a-8035-955f7a02eff9-051",
        "trade_date": 1501095828824
    },
    ...
]
```
