### PR TITLE
html escape values passed in by ?callback param 

### DIFF
--- a/api/hloc/index.php
+++ b/api/hloc/index.php
@@ -28,6 +28,13 @@ if( !$market ) {
     bail( "market parameter missing." );
 }
 
+// make it harder to inject random things into the output.
+if( $callback && (substr($callback, 0, 6) != 'jQuery' ||
+                  strlen($callback) > 50)) {
+	bail( "Invalid callback parameter." );
+}
+
+
 try {
 
 	$network = primary_market::determine_network_from_market($market);
@@ -121,7 +128,7 @@ try {
 	}
 	
 	if( $format == 'jscallback' ) {
-		echo $callback . "([\n";
+		echo htmlentities($callback) . "([\n";
 		foreach( $rows as $k => $row ) {
 			if( $milliseconds ) {
 				$row['period_start'] *= 1000;

--- a/api/volumes/index.php
+++ b/api/volumes/index.php
@@ -29,6 +29,12 @@ if( !$market && !$basecurrency ) {
     bail( "missing parameter.  either market or basecurrency must be present." );
 }
 
+// make it harder to inject random things into the output.
+if( $callback && (substr($callback, 0, 6) != 'jQuery' ||
+                  strlen($callback) > 50)) {
+	bail( "Invalid callback parameter." );
+}
+
 // normalize market=all to null.
 if( $market == 'all') {
     $market = null;
@@ -129,7 +135,7 @@ try {
 	}
 	
 	if( $format == 'jscallback' ) {
-		echo $callback . "([\n";
+		echo htmlentities($callback) . "([\n";
 		foreach( $rows as $k => $row ) {
 			if( $milliseconds ) {
 				$row['period_start'] *= 1000;


### PR DESCRIPTION
This PR fixes a possible XSS vector via the ?callback parameter in the hloc and volumes APIs.

Previously these values were output to the caller unescaped.

The fix also does minor sanitation of the callback value, which is intended for use by the graph component of the website and should always start with "jQuery".