### PR TITLE
replace apcu caching with opcache and re-enable caching.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ more efficient strategies.
 # Requirements
 
 * Apache or other webserver with php 5.5+
-* apcu extension.  ( for shared mem caching. will run without, but slower. )
+* opcache extension.  ( for data caching. will run without, but much slower. )
 
 # Installation
 

--- a/lib/filecache.class.php
+++ b/lib/filecache.class.php
@@ -21,8 +21,7 @@ class filecache {
     
     static public function get( $file, $key, $value_cb, $value_cb_params=[] ) {
         
-        // It turns out that apcu_fetch/entry is quite slow for large objects.
-        // So we use apcu for inter-request cache, and static var to cache during same request/process.
+        // We use opcache for inter-request cache, and static var to cache during same request/process.
         // todo: check if file has changed during same request/process. (lazy, eg after 2 secs)
         //       (checking mtime is slower and not really needed for use in a web app that is request oriented.)
         static $results = [];
@@ -32,53 +31,67 @@ class filecache {
             return $val;
         } 
        
-        // in case apcu is not installed.
-        if( true || !function_exists( 'apcu_fetch' ) ) {
+        $result_key = $fullkey;
+        $ts_key = $fullkey . '_timestamp';
+        
+        // Note: in older releases, we used apcu extension, but it turns out
+        // that opcache is much much faster.  For example, the trades API
+        // delivers approx 40 reqs/sec with apcu, and approx 1450 reqs/sec
+        // with opcache.  It seems that apcu is deserializing data each
+        // request, but opcache keeps it in parsed state in memory.
+        // see: https://medium.com/@dylanwenzlau/500x-faster-caching-than-redis-memcache-apc-in-php-hhvm-dcd26e8447ad
+        
+        // in case opcache is not installed or not enabled.
+        if( !extension_loaded( 'Zend OPcache' ) || !ini_get('opcache.enable')) {
             static $warned = false;
             if( !$warned ) {
-                error_log( "Warning: APCu not found. Please install APCu extension for better performance." );
+                error_log( "Warning: opcache not found. Please install or enable opcache extension for better performance." );
                 $warned = true;
             }
             $results[$fullkey] = $val = call_user_func_array( $value_cb, $value_cb_params );
             return $val;
         }
 
-        $result_key = $fullkey;
-        $ts_key = $fullkey . '_timestamp';
-
-        // We prefer to use apcu_entry if existing, because it is atomic.        
-        // note: disabling this for now because the trades class get_by_market callback
-        //       causes a second invocation of this method and apcu_entry crashes
-        //       when this occurs.  If I ever get time it would be good to make a
-        //       simplifieid test case and submit to the apc devs.
-        if( false && function_exists( 'apcu_entry' ) ) {
-            // note:  this case is untested!!!  my version of apcu is too old.
-            $cached_ts = apcu_entry( $ts_key, function($key) { return time(); } );
-            
-            // invalidate cache if file on disk is newer than cached value.
-            if( filemtime( $file ) > $cached_ts ) {
-                apcu_delete( $result_key );
-            }
-            $result = apcu_entry( $result_key, function($key) use($file, $value_cb, $value_cb_params) {
-                return call_user_func_array( $value_cb, $value_cb_params );
-            });
-            $results[$fullkey] = $result;
-            return $result;
-        }
+        // note: I experimented with storing timestamp and data in a
+        // single key/val array, to perform 1 cache lookup instead of
+        // 2, but there was no visible speedup.
+        $cached_ts = self::opcache_get( $ts_key );
         
-        // Otherwise, use apcu_fetch, apcu_store.
-        $cached_ts = apcu_fetch( $ts_key );
-        $cached_result = apcu_fetch( $result_key );
-
-        if( $cached_result && $cached_ts && filemtime( $file ) < $cached_ts ) {
-            $result = $cached_result;
+        if( $cached_ts && filemtime( $file ) < $cached_ts ) {
+            $result = self::opcache_get( $result_key );
         }
-        else {
+        if(@$result === null) {
             $result = call_user_func_array( $value_cb, $value_cb_params );
-            apcu_store( $ts_key, time() );
-            apcu_store( $result_key, $result );
+            self::opcache_set( $ts_key, time() );
+            self::opcache_set( $result_key, $result );
         }
         $results[$fullkey] = $result;
         return $result;
+        
+    }
+
+    // store key/val in opcache.    
+    static function opcache_set($key, $val) {
+       $val = var_export($val, true);
+       // HHVM fails at __set_state, so just use object cast for now
+       $val = str_replace('stdClass::__set_state', '(object)', $val);
+       // Write to temp file first to ensure atomicity
+       $safekey = md5($key);
+       $dir = '/tmp/bisq_opcache';
+       @mkdir($dir);
+       $tmp = "$dir/$safekey." . uniqid('', true) . '.tmp';
+       file_put_contents($tmp, '<?php $val = ' . $val . ';', LOCK_EX);
+       rename($tmp, "$dir/$safekey");
+    }
+    
+    // retrieve key from opcache.
+    // note that first call to get will read file from disk, but
+    // subsequent operations retrieve parsed object from ram.
+    static function opcache_get($key) {
+       $safekey = md5($key);
+        @include "/tmp/bisq_opcache/$safekey";
+        return isset($val) ? $val : false;
     }
 }
+
+


### PR DESCRIPTION
This PR uses PHP's builtin opcache extension to cache Bisq's large JSON files between http requests, instead of the apcu extension which was slow and previously disabled.

Opcache is intended for caching PHP code files.  This patch uses a little trick to write out the JSON data structures as "php code" to a file on disk, and then each cache read calls PHP's include() function to read the file, which internally accesses the parsed data from RAM rather than from disk.  The pre-existing caching logic in filecache.class.php is smart enough to invalidate the cache key whenever one of the Bisq JSON files is updated by the Bisq java app.  Thus, the cache never gets stale.

In local testing on a laptop the /trades api went from approx 25 requests/sec to 1450 reqs/sec and front page load from about 20 reqs/sec to 230 reqs/sec.