### PR TITLE
Add Schema.org JSON-LD Microdata for SEO

### DIFF
--- a/static/api/index.html
+++ b/static/api/index.html
@@ -827,4 +827,20 @@ div.params div {
 </div>
 
 </body>
+  
+  <!-- SCHEMA.ORG MICRODATA FOR SEO -->
+  <script type="application/ld+json">
+  {
+    "@context": "http://schema.org/",
+    "@type": "WebAPI",
+    "name": "Bisq Markets API service",
+    "description": "This public API serves data on Bisq offers, trades, and historical statistics.",
+    "documentation": "https://markets.bisq.network/api/",
+    "provider": {
+      "@type": "Project",
+      "name": "Bisq Network",
+      "url": "https://bisq.network/"
+    }
+  }
+  </script>
 </html>


### PR DESCRIPTION
Following https://github.com/bisq-network/bisq-website/pull/290/, https://github.com/bisq-network/bisq-website/pull/291/, https://github.com/bisq-network/bisq-website/pull/307/

**Why use markups on Bisq?
Marking up content on Bisq website can:**

- Lead to the generation of rich snippets in search engine results like the one showed on top
- Enhance CTR (Click Through Rate) from the search result
- Provide greater information to search engines to improve their understanding of the content on Bisq website

Read more about the importance of Rich Snippets: https://yoast.com/what-are-rich-snippets/