### PR TITLE
apache2 MaxRequestWorkers tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Recommended to set in /etc/apache2/mods-available/mpm_prefork.conf
         StartServers             20
         MinSpareServers          10
         MaxSpareServers          20
-        MaxRequestWorkers        50
+        MaxRequestWorkers        30
         MaxConnectionsPerChild   0
 </IfModule>
 ```


### PR DESCRIPTION
The server is running out of memory all the time. And the linux oom killer kills mostly the bisq java process.
The fix is lowering the maximal apache2 workers from 50 to 30. 
Now it is running fine.